### PR TITLE
Add ability to download specific version from ID input

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,7 +33,7 @@ var getCmd = &cobra.Command{
 
 		downloader := tinys3cli.NewS3Downloader(n_jobs)
 
-		versionId, err := cmd.Flags().GetString("version ID")
+		versionId, err := cmd.Flags().GetString("version-id")
 		if err != nil {
 			versionId = ""
 		}
@@ -56,7 +56,7 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().BoolP("recursive", "r", false, "download recursively")
 	getCmd.Flags().IntP("jobs", "j", 4, "max parallel jobs")
-	getCmd.Flags().StringP("version ID", "v", "", "file version ID")
+	getCmd.Flags().StringP("version-id", "v", "", "file version ID")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -30,8 +30,15 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			n_jobs = 4
 		}
+
 		downloader := tinys3cli.NewS3Downloader(n_jobs)
-		err = downloader.Submit(localPath, remotePath, bucketName, recursive)
+
+		versionId, err := cmd.Flags().GetString("version")
+		if err != nil {
+			versionId = ""
+		}
+
+		err = downloader.Submit(localPath, remotePath, bucketName, recursive, versionId)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -46,6 +53,7 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().BoolP("recursive", "r", false, "download recursively")
 	getCmd.Flags().IntP("jobs", "j", 4, "max parallel jobs")
+	getCmd.Flags().StringP("version", "v", "", "file version ID")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -33,7 +33,7 @@ var getCmd = &cobra.Command{
 
 		downloader := tinys3cli.NewS3Downloader(n_jobs)
 
-		versionId, err := cmd.Flags().GetString("version")
+		versionId, err := cmd.Flags().GetString("version ID")
 		if err != nil {
 			versionId = ""
 		}
@@ -53,7 +53,7 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().BoolP("recursive", "r", false, "download recursively")
 	getCmd.Flags().IntP("jobs", "j", 4, "max parallel jobs")
-	getCmd.Flags().StringP("version", "v", "", "file version ID")
+	getCmd.Flags().StringP("version ID", "v", "", "file version ID")
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -37,6 +37,9 @@ var getCmd = &cobra.Command{
 		if err != nil {
 			versionId = ""
 		}
+		if versionId != "" && recursive {
+			log.Fatal("Error: Version ID cannot be specified when downloading recursively")
+		}
 
 		err = downloader.Submit(localPath, remotePath, bucketName, recursive, versionId)
 		if err != nil {

--- a/pkg/download.go
+++ b/pkg/download.go
@@ -113,7 +113,7 @@ func (downloader *S3Downloader) Submit(localPath, remotePath, bucketName string,
 				}
 
 				filePath := path.Join(dirPath, fileName)
-				err = doDownload(client, filePath, *obj.Key, bucketName, versionId)
+				err = doDownload(client, filePath, *obj.Key, bucketName, "")
 				if err != nil {
 					log.Printf("error on %s, %s", *obj.Key, err)
 					downloader.SetLastErr(err)

--- a/pkg/download.go
+++ b/pkg/download.go
@@ -15,8 +15,14 @@ import (
 	"github.com/gammazero/workerpool"
 )
 
-func doDownload(client *s3.Client, localPath, remotePath, bucketName string) error {
-	output, err := client.GetObject(context.TODO(), &s3.GetObjectInput{Bucket: &bucketName, Key: &remotePath})
+func doDownload(client *s3.Client, localPath, remotePath, bucketName string, versionId ...string) error {
+	var output *s3.GetObjectOutput
+	var err error
+	if len(versionId) > 0 {
+		output, err = client.GetObject(context.TODO(), &s3.GetObjectInput{Bucket: &bucketName, Key: &remotePath, VersionId: &versionId[0]})
+	} else {
+		output, err = client.GetObject(context.TODO(), &s3.GetObjectInput{Bucket: &bucketName, Key: &remotePath})
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a version ID argument to the `get` program. If specified, that version is downloaded.

As far as I can tell, `VersionId` is simply a property of `s3.GetObjectInput`.

_Unfortunately I cannot test this change because there is some problem with my configuration of AWS SSO/tinys3cli. I will try to fix this and test next week if you have not done so by then._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now specify a file version ID when using the `get` command to download specific versions of files.

- **Enhancements**
  - Improved the download functionality to handle version IDs for targeted file retrieval.

- **Bug Fixes**
  - Added validation to prevent the use of version IDs when performing recursive downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->